### PR TITLE
Fix #8 Remove agetty target from systemd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,7 @@ RUN chmod +x initctl_faker && rm -fr /sbin/initctl && ln -s /initctl_faker /sbin
 RUN mkdir -p /etc/ansible
 RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 
+RUN rm -f /lib/systemd/system/multi-user.target.wants/getty.target
+
 VOLUME ["/sys/fs/cgroup"]
 CMD ["/lib/systemd/systemd"]


### PR DESCRIPTION
This removes the agetty.target from the multi-user target so the
systemd container will not start agettys on tty[1-6].

Signed-off-by: David Brown <dmlb2000@gmail.com>